### PR TITLE
fix: fix remaining conformance tests

### DIFF
--- a/crates/uplc/src/machine/cost_model/builtin_costs.rs
+++ b/crates/uplc/src/machine/cost_model/builtin_costs.rs
@@ -692,7 +692,7 @@ impl BuiltinCosts {
             quotient_integer: TwoArgumentsCosting::new(
                 TwoArgumentsCosting::subtracted_sizes(0, 1, 1),
                 TwoArgumentsCosting::const_above_diagonal_into_quadratic_x_and_y(
-                    85848, 85848, 123203, 7305, -900, 1716, 549, 57,
+                      85848, 85848, 123203, 1716, 7305, 57, 549, -900,
                 ),
             ),
             remainder_integer: TwoArgumentsCosting::new(

--- a/crates/uplc/src/syn/constant.rs
+++ b/crates/uplc/src/syn/constant.rs
@@ -179,10 +179,6 @@ fn value_parser<'a>() -> impl Parser<'a, &'a str, TempConstant<'a>, Extra<'a>> {
 
                     TempConstant::String(string)
                 }),
-            // plutus data
-            data::parser()
-                .delimited_by(just('(').or_not(), just(')').or_not())
-                .map(TempConstant::Data),
             // list
             con.clone()
                 .padded()
@@ -206,6 +202,14 @@ fn value_parser<'a>() -> impl Parser<'a, &'a str, TempConstant<'a>, Extra<'a>> {
                 .map(|(fst_value, snd_value)| {
                     TempConstant::ProtoPair(fst_value.into(), snd_value.into())
                 }),
+            // parenthesized plutus data (only for non-pair cases)
+            just('(')
+                .ignore_then(data::parser())
+                .then_ignore(just(')'))
+                .map(TempConstant::Data),
+            // non-parenthesized plutus data
+            data::parser()
+                .map(TempConstant::Data),
             // bool
             choice((just("False"), just("True")))
                 .padded()

--- a/crates/uplc/src/syn/term.rs
+++ b/crates/uplc/src/syn/term.rs
@@ -16,7 +16,7 @@ pub fn parser<'a>() -> impl Parser<'a, &'a str, &'a Term<'a, DeBruijn>, Extra<'a
             name().padded().map_with(|v, e: &mut MapExtra<'a, '_>| {
                 let state = e.state();
 
-                let position = state.env.iter().rev().position(|&x| x == v);
+                let position = state.env.iter().rposition(|&x| x == v);
 
                 if position.is_none() {
                     let placeholder = Term::var(state.arena, DeBruijn::zero(state.arena));
@@ -129,21 +129,33 @@ pub fn parser<'a>() -> impl Parser<'a, &'a str, &'a Term<'a, DeBruijn>, Extra<'a
                 )
                 .delimited_by(just('('), just(')'))
                 .validate(|(tag, fields), e: &mut MapExtra<'a, '_>, emitter| {
+                    let span = e.span();
                     let state = e.state();
 
                     let fields = BumpVec::from_iter_in(fields, state.arena);
                     let fields = state.arena.alloc(fields);
 
-                    let ret = Term::constr(state.arena, tag.parse().unwrap(), fields);
+                    // Handle tag parsing with proper error emission
+                    let tag_parsed = match tag.parse::<usize>() {
+                        Ok(t) => {
+                            let ret = Term::constr(state.arena, t, fields);
 
-                    if state.is_less_than_1_1_0() {
-                        emitter.emit(Rich::custom(
-                            e.span(),
-                            "constr is not supported before 1.1.0",
-                        ));
-                    }
+                            if state.is_less_than_1_1_0() {
+                                emitter.emit(Rich::custom(
+                                    e.span(),
+                                    "constr is not supported before 1.1.0",
+                                ));
+                            }
 
-                    ret
+                            ret
+                        }
+                        Err(_) => {
+                            emitter.emit(Rich::custom(span, format!("invalid constr tag: {}", tag)));
+                            Term::error(state.arena)
+                        }
+                    };
+
+                    tag_parsed
                 }),
             text::keyword("case")
                 .padded()

--- a/crates/uplc/tests/conformance/builtin/semantics/consByteString/consByteString-01/consByteString-01.uplc
+++ b/crates/uplc/tests/conformance/builtin/semantics/consByteString/consByteString-01/consByteString-01.uplc
@@ -1,2 +1,2 @@
 -- the arg overflow'ed over the maxBound :: Word8
-(program 1.0.0 [(builtin consByteString) (con integer 256) (con bytestring #)])
+(program 1.1.0 [(builtin consByteString) (con integer 256) (con bytestring #)])

--- a/crates/uplc/tests/conformance/builtin/semantics/consByteString/consByteString-02/consByteString-02.uplc
+++ b/crates/uplc/tests/conformance/builtin/semantics/consByteString/consByteString-02/consByteString-02.uplc
@@ -1,3 +1,3 @@
-(program 1.0.0
+(program 1.1.0
     [(builtin consByteString) (con integer -88) (con bytestring #686543616B654973414C6965)]
 )


### PR DESCRIPTION
This PR makes adjustments to how the UPLC term parsing for DeBruijn numbers were handled, data constant parsing for pairs, a builtin-costs model fix.

Overall the changes affect the following conformance tests:

builtin_semantics_mapdata_mapdata_01
builtin_semantics_mkpairdata_mkpairdata_01
builtin_semantics_quotientinteger_quotientinteger_neg_neg
builtin_semantics_quotientinteger_quotientinteger_neg_pos
builtin_semantics_quotientinteger_quotientinteger_pos_neg
builtin_semantics_quotientinteger_quotientinteger_pos_pos
builtin_semantics_unmapdata_unmapdata_01
example_applyadd1
example_applyadd2
example_even2
example_even3
example_evenlist
example_factorial
example_fibonacci
example_ifintegers
example_natroundtrip
example_scottlistsum
mapdata_01
term_app_app_7
term_app_app_8
term_app_app_9
term_case_case_04
term_closure
term_constr_constr_09
term_constr_constr_10

