### PR TITLE
feat: added builtin cost model A

### DIFF
--- a/crates/uplc/src/machine/cost_model/builtin_costs.rs
+++ b/crates/uplc/src/machine/cost_model/builtin_costs.rs
@@ -706,6 +706,387 @@ impl BuiltinCosts {
         )
     }
 
+    pub fn v1() -> Self {
+        Self {
+            add_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::max_size(1, 1),
+                TwoArgumentsCosting::max_size(205665, 812),
+            ),
+            subtract_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::max_size(1, 1),
+                TwoArgumentsCosting::max_size(205665, 812),
+            ),
+            multiply_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::added_sizes(0, 1),
+                TwoArgumentsCosting::added_sizes(69522, 11687),
+            ),
+            divide_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::subtracted_sizes(0, 1, 1),
+                TwoArgumentsCosting::const_above_diagonal_into_multiplied_sizes(
+                    196500, 453240, 220,
+                ),
+            ),
+            quotient_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::subtracted_sizes(0, 1, 1),
+                TwoArgumentsCosting::const_above_diagonal_into_multiplied_sizes(
+                    196500, 453240, 220,
+                ),
+            ),
+            remainder_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::subtracted_sizes(0, 1, 1),
+                TwoArgumentsCosting::const_above_diagonal_into_multiplied_sizes(
+                    196500, 453240, 220,
+                ),
+            ),
+            mod_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::subtracted_sizes(0, 1, 1),
+                TwoArgumentsCosting::const_above_diagonal_into_multiplied_sizes(
+                    196500, 453240, 220,
+                ),
+            ),
+            equals_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::min_size(208512, 421),
+            ),
+            less_than_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::min_size(208896, 511),
+            ),
+            less_than_equals_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::min_size(204924, 473),
+            ),
+            append_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::added_sizes(0, 1),
+                TwoArgumentsCosting::added_sizes(1000, 571),
+            ),
+            cons_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::added_sizes(0, 1),
+                TwoArgumentsCosting::linear_in_y(221973, 511),
+            ),
+            slice_byte_string: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::linear_in_z(4, 0),
+                ThreeArgumentsCosting::linear_in_z(265318, 0),
+            ),
+            length_of_byte_string: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(10),
+                OneArgumentCosting::constant_cost(1000),
+            ),
+            index_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(4),
+                TwoArgumentsCosting::constant_cost(57667),
+            ),
+            equals_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::linear_on_diagonal(245000, 216773, 62),
+            ),
+            less_than_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::min_size(197145, 156),
+            ),
+            less_than_equals_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::min_size(197145, 156),
+            ),
+            sha2_256: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(4),
+                OneArgumentCosting::linear_cost(806990, 30482),
+            ),
+            sha3_256: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(4),
+                OneArgumentCosting::linear_cost(1927926, 82523),
+            ),
+            blake2b_256: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(4),
+                OneArgumentCosting::linear_cost(117366, 10475),
+            ),
+            verify_ed25519_signature: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::constant_cost(10),
+                ThreeArgumentsCosting::linear_in_z(57996947, 18975),
+            ),
+            verify_ecdsa_secp256k1_signature: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::constant_cost(10),
+                ThreeArgumentsCosting::constant_cost(35190005),
+            ),
+            verify_schnorr_secp256k1_signature: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::constant_cost(10),
+                ThreeArgumentsCosting::linear_in_y(39121781, 32260),
+            ),
+            append_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::added_sizes(4, 1),
+                TwoArgumentsCosting::added_sizes(1000, 24177),
+            ),
+            equals_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::linear_on_diagonal(187000, 1000, 52998),
+            ),
+            encode_utf8: OneArgumentCosting::new(
+                OneArgumentCosting::linear_cost(4, 2),
+                OneArgumentCosting::linear_cost(1000, 28662),
+            ),
+            decode_utf8: OneArgumentCosting::new(
+                OneArgumentCosting::linear_cost(4, 2),
+                OneArgumentCosting::linear_cost(497525, 14068),
+            ),
+            if_then_else: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::constant_cost(1),
+                ThreeArgumentsCosting::constant_cost(80556),
+            ),
+            choose_unit: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(4),
+                TwoArgumentsCosting::constant_cost(46417),
+            ),
+            trace: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(32),
+                TwoArgumentsCosting::constant_cost(212342),
+            ),
+            fst_pair: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(80436),
+            ),
+            snd_pair: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(85931),
+            ),
+            choose_list: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::constant_cost(32),
+                ThreeArgumentsCosting::constant_cost(175354),
+            ),
+            mk_cons: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(32),
+                TwoArgumentsCosting::constant_cost(65493),
+            ),
+            head_list: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(43249),
+            ),
+            tail_list: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(41182),
+            ),
+            null_list: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(60091),
+            ),
+            choose_data: SixArgumentsCosting::new(
+                SixArgumentsCosting::constant_cost(32),
+                SixArgumentsCosting::constant_cost(19537),
+            ),
+            constr_data: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(32),
+                TwoArgumentsCosting::constant_cost(89141),
+            ),
+            map_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(64832),
+            ),
+            list_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(52467),
+            ),
+            i_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(1000),
+            ),
+            b_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(1000),
+            ),
+            un_constr_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(32696),
+            ),
+            un_map_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(38314),
+            ),
+            un_list_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(32247),
+            ),
+            un_i_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(43357),
+            ),
+            un_b_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(31220),
+            ),
+            equals_data: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::min_size(1060367, 12586),
+            ),
+            mk_pair_data: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(32),
+                TwoArgumentsCosting::constant_cost(76511),
+            ),
+            mk_nil_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(22558),
+            ),
+            mk_nil_pair_data: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(32),
+                OneArgumentCosting::constant_cost(16563),
+            ),
+            serialise_data: OneArgumentCosting::new(
+                OneArgumentCosting::linear_cost(0, 2),
+                OneArgumentCosting::linear_cost(1159724, 392670),
+            ),
+            blake2b_224: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(4),
+                OneArgumentCosting::linear_cost(117366, 10475),
+            ),
+            keccak_256: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(4),
+                OneArgumentCosting::linear_cost(2261318, 64571),
+            ),
+            bls12_381_g1_add: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(18),
+                TwoArgumentsCosting::constant_cost(962335),
+            ),
+            bls12_381_g1_neg: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(18),
+                OneArgumentCosting::constant_cost(267929),
+            ),
+            bls12_381_g1_scalar_mul: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(18),
+                TwoArgumentsCosting::linear_in_x(76433006, 8868),
+            ),
+            bls12_381_g1_equal: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::constant_cost(442008),
+            ),
+            bls12_381_g1_compress: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(6),
+                OneArgumentCosting::constant_cost(2780678),
+            ),
+            bls12_381_g1_uncompress: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(18),
+                OneArgumentCosting::constant_cost(52948122),
+            ),
+            bls12_381_g1_hash_to_group: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(18),
+                TwoArgumentsCosting::linear_in_x(52538055, 3756),
+            ),
+            bls12_381_g2_add: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(36),
+                TwoArgumentsCosting::constant_cost(1995836),
+            ),
+            bls12_381_g2_neg: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(36),
+                OneArgumentCosting::constant_cost(284546),
+            ),
+            bls12_381_g2_scalar_mul: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(36),
+                TwoArgumentsCosting::linear_in_x(158_221_314, 26_549),
+            ),
+            bls12_381_g2_equal: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::constant_cost(901_022),
+            ),
+            bls12_381_g2_compress: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(12),
+                OneArgumentCosting::constant_cost(3_227_919),
+            ),
+            bls12_381_g2_uncompress: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(36),
+                OneArgumentCosting::constant_cost(74_698_472),
+            ),
+            bls12_381_g2_hash_to_group: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(36),
+                TwoArgumentsCosting::linear_in_x(166_917_843, 4_307),
+            ),
+            bls12_381_miller_loop: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(72),
+                TwoArgumentsCosting::constant_cost(254006273),
+            ),
+            bls12_381_mul_ml_result: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(72),
+                TwoArgumentsCosting::constant_cost(2174038),
+            ),
+            bls12_381_final_verify: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::constant_cost(333849714),
+            ),
+            integer_to_byte_string: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::literal_in_y_or_linear_in_z(0, 1),
+                ThreeArgumentsCosting::quadratic_in_z(1293828, 28716, 63),
+            ),
+            byte_string_to_integer: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::linear_in_y(0, 1),
+                TwoArgumentsCosting::quadratic_in_y(1006041, 43623, 251),
+            ),
+            and_byte_string: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::linear_in_max_y_z(0, 1),
+                ThreeArgumentsCosting::linear_in_y_and_z(100181, 726, 719),
+            ),
+            or_byte_string: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::linear_in_max_y_z(0, 1),
+                ThreeArgumentsCosting::linear_in_y_and_z(100181, 726, 719),
+            ),
+            xor_byte_string: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::linear_in_max_y_z(0, 1),
+                ThreeArgumentsCosting::linear_in_y_and_z(100181, 726, 719),
+            ),
+            complement_byte_string: OneArgumentCosting::new(
+                OneArgumentCosting::linear_cost(0, 1),
+                OneArgumentCosting::linear_cost(107878, 680),
+            ),
+            read_bit: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(1),
+                TwoArgumentsCosting::constant_cost(95336),
+            ),
+            write_bits: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::linear_in_x(0, 1),
+                ThreeArgumentsCosting::linear_in_y(281145, 18848),
+            ),
+            replicate_byte: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::linear_in_x(1, 1),
+                TwoArgumentsCosting::linear_in_x(180194, 159),
+            ),
+            shift_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::linear_in_x(0, 1),
+                TwoArgumentsCosting::linear_in_x(158519, 8942),
+            ),
+            rotate_byte_string: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::linear_in_x(0, 1),
+                TwoArgumentsCosting::linear_in_x(159378, 8813),
+            ),
+            count_set_bits: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(1),
+                OneArgumentCosting::linear_cost(107490, 3298),
+            ),
+            find_first_set_bit: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(1),
+                OneArgumentCosting::linear_cost(106057, 655),
+            ),
+            ripemd_160: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(3),
+                OneArgumentCosting::linear_cost(1964219, 24520),
+            ),
+            exp_mod_integer: ThreeArgumentsCosting::new(
+                ThreeArgumentsCosting::linear_in_z(0, 1),
+                ThreeArgumentsCosting::exp_mod_cost(607153, 231697, 53144),
+            ),
+            drop_list: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(4),
+                TwoArgumentsCosting::linear_in_x(116711, 1957),
+            ),
+            length_of_array: OneArgumentCosting::new(
+                OneArgumentCosting::constant_cost(10),
+                OneArgumentCosting::constant_cost(198994),
+            ),
+            list_to_array: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::linear_in_x(7, 1),
+                TwoArgumentsCosting::linear_in_x(307802, 8496),
+            ),
+            index_array: TwoArgumentsCosting::new(
+                TwoArgumentsCosting::constant_cost(32),
+                TwoArgumentsCosting::constant_cost(194922),
+            ),
+        }
+    }
+
     pub fn v3() -> Self {
         Self {
             add_integer: TwoArgumentsCosting::new(

--- a/crates/uplc/src/machine/cost_model/costing.rs
+++ b/crates/uplc/src/machine/cost_model/costing.rs
@@ -60,6 +60,7 @@ pub enum TwoArguments {
     LinearOnDiagonal(ConstantOrLinear),
     QuadraticInY(QuadraticFunction),
     ConstAboveDiagonalIntoQuadraticXAndY(i64, TwoArgumentsQuadraticFunction),
+    ConstAboveDiagonalIntoMultipliedSizes(i64, MultipliedSizes),
 }
 
 pub type TwoArgumentsCosting = Costing<2, TwoArguments>;
@@ -141,6 +142,17 @@ impl TwoArgumentsCosting {
             coeff_2,
         })
     }
+
+    pub fn const_above_diagonal_into_multiplied_sizes(
+        constant: i64,
+        intercept: i64,
+        slope: i64,
+    ) -> TwoArguments {
+        TwoArguments::ConstAboveDiagonalIntoMultipliedSizes(
+            constant,
+            MultipliedSizes { intercept, slope },
+        )
+    }
 }
 
 impl Cost<2> for TwoArguments {
@@ -178,6 +190,13 @@ impl Cost<2> for TwoArguments {
                             + q.coeff_11 * x * y
                             + q.coeff_02 * y * y,
                     )
+                }
+            }
+            TwoArguments::ConstAboveDiagonalIntoMultipliedSizes(constant, s) => {
+                if x < y {
+                    *constant
+                } else {
+                    s.slope * (x * y) + s.intercept
                 }
             }
         }


### PR DESCRIPTION
This PR adds the cost models for [builtinCostModelA](https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelA.json)