### PR TITLE
Allow fine-grained time analysis of turbo benches.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -75,4 +75,4 @@ jobs:
           ls -la crates/uplc/benches/turbo/samples
 
       - name: Run benchmarks
-        run: cargo bench --bench turbo
+        run: cargo bench --bench turbo -F alloc_profiler

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1279,6 +1279,7 @@ dependencies = [
  "once_cell",
  "ouroboros",
  "pretty_assertions",
+ "rayon",
  "secp256k1",
  "thiserror",
  "uplc_macros",

--- a/crates/uplc/Cargo.toml
+++ b/crates/uplc/Cargo.toml
@@ -34,6 +34,10 @@ itertools = "0.13.0"
 ouroboros = "0.18.4"
 pretty_assertions = "1.4.0"
 uplc_macros = { version = "0.1.0", path = "../uplc_macros" }
+rayon = "1.11.0"
+
+[features]
+alloc_profiler = []
 
 [[bench]]
 name = "simple"


### PR DESCRIPTION
## Standard bench

```
cargo bench --bench turbo
```

```
turbo     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ turbo  6.796 µs      │ 208.6 ms      │ 238 µs        │ 352.6 µs      │ 479264  │ 479264
```


## With the allocation profiling

```
cargo bench --bench turbo -F alloc_profiler
```

```
turbo     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ turbo  6.796 µs      │ 208.6 ms      │ 238 µs        │ 352.6 µs      │ 479264  │ 479264
          max alloc:    │               │               │               │         │
            18          │ 155           │ 32            │ 194.6         │         │
            1.28 KB     │ 7.219 MB      │ 8.728 KB      │ 17.85 KB      │         │
```

## Identifying slow cases 

```
UPLC_TURBO_ANALYZE_SLOW=100 cargo bench --bench turbo
```

```
== Collecting script executions slower than 100ms
8100C5F1EEA24F95A286A6E5768CC3DD45284332E33E53426366939C8F7DC431-0-D0E1E5DC60D29AFD73D24798E7525132CED5D77C24FC1FFAF9B43FE0-v2 in 250ms 
    elapsed unflat: 10μs
    elapsed eval:   250ms 
    elapsed reset:  63μs 
F1ED4AA0855CBFEA275E26D138C78D106181B604E735601D15FCFF5988ED290B-0-D0E1E5DC60D29AFD73D24798E7525132CED5D77C24FC1FFAF9B43FE0-v2 in 251ms 
    elapsed unflat: 10μs
    elapsed eval:   250ms
    elapsed reset:  211μs 
F43639737E9AA79A34DDFE7C00750CBF0A8F4E0C1FF3434AA5EA766FD3D46C7F-0-D0E1E5DC60D29AFD73D24798E7525132CED5D77C24FC1FFAF9B43FE0-v2 in 244ms
    elapsed unflat: 9μs
    elapsed eval:   244ms 
    elapsed reset:  66μs
FB42B86CC631D807E026293CFD6CDBD6E6FC8AB49128F669D7A5B4C3EAAEBF99-0-D0E1E5DC60D29AFD73D24798E7525132CED5D77C24FC1FFAF9B43FE0-v2 in 242ms 
    elapsed unflat: 10μs
    elapsed eval:   242ms 
    elapsed reset:  306μs
```


