### PR TITLE
Fix Decoding Logic

### DIFF
--- a/crates/pluton/src/cmd/eval.rs
+++ b/crates/pluton/src/cmd/eval.rs
@@ -13,6 +13,8 @@ pub struct Args {
     args: Vec<String>,
     #[clap(short = 'v', long)]
     plutus_version: Option<String>,
+    #[clap(short = 'p', long, default_value = "10")]
+    protocol_version: u32,
 }
 
 fn parse_plutus_version(s: &str) -> Result<PlutusVersion, String> {
@@ -42,6 +44,12 @@ impl Args {
         let bump = uplc_turbo::bumpalo::Bump::with_capacity(1_024_000);
         let arena = uplc_turbo::arena::Arena::from_bump(bump);
 
+        let plutus_version = match &self.plutus_version {
+            Some(v) => parse_plutus_version(v).map_err(|e| miette::miette!("{}", e))?,
+            None => PlutusVersion::V3,
+        };
+        let pv = self.protocol_version;
+
         let program = if let Some(file_path) = self.file {
             std::fs::read(file_path).into_diagnostic()?
         } else {
@@ -55,7 +63,7 @@ impl Args {
         let mut program_string = String::new();
 
         let program = if self.flat {
-            uplc_turbo::flat::decode(&arena, &program).into_diagnostic()?
+            uplc_turbo::flat::decode(&arena, &program, plutus_version, pv).into_diagnostic()?
         } else {
             {
                 let temp = String::from_utf8(program).into_diagnostic()?;

--- a/crates/pluton/src/cmd/eval.rs
+++ b/crates/pluton/src/cmd/eval.rs
@@ -48,7 +48,7 @@ impl Args {
             Some(v) => parse_plutus_version(v).map_err(|e| miette::miette!("{}", e))?,
             None => PlutusVersion::V3,
         };
-        let pv = self.protocol_version;
+        let protocol_version = self.protocol_version;
 
         let program = if let Some(file_path) = self.file {
             std::fs::read(file_path).into_diagnostic()?
@@ -63,7 +63,8 @@ impl Args {
         let mut program_string = String::new();
 
         let program = if self.flat {
-            uplc_turbo::flat::decode(&arena, &program, plutus_version, pv).into_diagnostic()?
+            uplc_turbo::flat::decode(&arena, &program, plutus_version, protocol_version)
+                .into_diagnostic()?
         } else {
             {
                 let temp = String::from_utf8(program).into_diagnostic()?;

--- a/crates/uplc/benches/turbo/main.rs
+++ b/crates/uplc/benches/turbo/main.rs
@@ -111,6 +111,7 @@ fn collect_scripts(files: &[PathBuf]) -> Vec<(String, Vec<u8>, PlutusVersion)> {
 
 fn bench_turbo(arena: &mut Arena) -> impl FnMut(Vec<u8>, PlutusVersion) + use<'_> {
     move |flat, plutus_version| {
+        // TODO: We are hardcoding 10, the current mainnet protocol version. This should be an argument
         let program =
             flat::decode::<DeBruijn>(arena, &flat, plutus_version, 10).expect("Failed to decode");
 

--- a/crates/uplc/benches/turbo/main.rs
+++ b/crates/uplc/benches/turbo/main.rs
@@ -111,7 +111,8 @@ fn collect_scripts(files: &[PathBuf]) -> Vec<(String, Vec<u8>, PlutusVersion)> {
 
 fn bench_turbo(arena: &mut Arena) -> impl FnMut(Vec<u8>, PlutusVersion) + use<'_> {
     move |flat, plutus_version| {
-        let program = flat::decode::<DeBruijn>(arena, &flat).expect("Failed to decode");
+        let program =
+            flat::decode::<DeBruijn>(arena, &flat, plutus_version, 10).expect("Failed to decode");
 
         let result = program.eval_version_budget(arena, plutus_version, ExBudget::max());
 
@@ -128,7 +129,8 @@ fn analyze_turbo(
 ) -> (Duration, Duration, Duration) {
     let instant = Instant::now();
 
-    let program = flat::decode::<DeBruijn>(arena, &flat).expect("Failed to decode");
+    let program =
+        flat::decode::<DeBruijn>(arena, &flat, plutus_version, 10).expect("Failed to decode");
     let elapsed_unflat = instant.elapsed();
 
     let result = program.eval_version_budget(arena, plutus_version, ExBudget::max());

--- a/crates/uplc/benches/use_cases/main.rs
+++ b/crates/uplc/benches/use_cases/main.rs
@@ -27,8 +27,8 @@ pub fn bench_plutus_use_cases(c: &mut Criterion) {
 
             c.bench_function(&file_name, |b| {
                 b.iter(|| {
-                    let program =
-                        flat::decode::<DeBruijn>(&arena, &script, PlutusVersion::V3, 10).expect("Failed to decode");
+                    let program = flat::decode::<DeBruijn>(&arena, &script, PlutusVersion::V3, 10)
+                        .expect("Failed to decode");
 
                     let result = program.eval(&arena);
 

--- a/crates/uplc/benches/use_cases/main.rs
+++ b/crates/uplc/benches/use_cases/main.rs
@@ -2,7 +2,7 @@ use bumpalo::Bump;
 use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use std::{fs, time::Duration};
-use uplc_turbo::{arena::Arena, binder::DeBruijn, flat};
+use uplc_turbo::{arena::Arena, binder::DeBruijn, flat, machine::PlutusVersion};
 
 pub fn bench_plutus_use_cases(c: &mut Criterion) {
     let data_dir = std::path::Path::new("benches/use_cases/plutus_use_cases");
@@ -28,7 +28,7 @@ pub fn bench_plutus_use_cases(c: &mut Criterion) {
             c.bench_function(&file_name, |b| {
                 b.iter(|| {
                     let program =
-                        flat::decode::<DeBruijn>(&arena, &script).expect("Failed to decode");
+                        flat::decode::<DeBruijn>(&arena, &script, PlutusVersion::V3, 10).expect("Failed to decode");
 
                     let result = program.eval(&arena);
 

--- a/crates/uplc/benches/use_cases/turbo.rs
+++ b/crates/uplc/benches/use_cases/turbo.rs
@@ -134,7 +134,7 @@ fn bench_turbo(c: &mut Criterion) {
             group.bench_function(&file_name, |b| {
                 b.iter(|| {
                     let program =
-                        flat::decode::<DeBruijn>(&arena, &flat).expect("Failed to decode");
+                        flat::decode::<DeBruijn>(&arena, &flat, plutus_version, 10).expect("Failed to decode");
 
                     let result = program.eval_version(&arena, plutus_version);
 

--- a/crates/uplc/src/builtin/default_function.rs
+++ b/crates/uplc/src/builtin/default_function.rs
@@ -1,3 +1,5 @@
+use crate::machine::PlutusVersion;
+
 #[repr(u8)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -311,6 +313,159 @@ impl DefaultFunction {
             DefaultFunction::LengthOfArray => 1,
             DefaultFunction::ListToArray => 1,
             DefaultFunction::IndexArray => 2,
+        }
+    }
+
+    /// Check whether this builtin is available for a given Plutus ledger language
+    /// and major protocol version.
+    ///
+    /// Follows the Haskell's `builtinsIntroducedIn` mapping from plutus-ledger-api:
+    /// <https://github.com/IntersectMBO/plutus/blob/master/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs>
+    pub fn is_available_in(&self, plutus_version: PlutusVersion, pv: u32) -> bool {
+        use DefaultFunction::*;
+
+        // batch1: the original 51 builtins from Alonzo (PV 5)
+        let batch1 = matches!(
+            self,
+            AddInteger
+                | SubtractInteger
+                | MultiplyInteger
+                | DivideInteger
+                | QuotientInteger
+                | RemainderInteger
+                | ModInteger
+                | EqualsInteger
+                | LessThanInteger
+                | LessThanEqualsInteger
+                | AppendByteString
+                | ConsByteString
+                | SliceByteString
+                | LengthOfByteString
+                | IndexByteString
+                | EqualsByteString
+                | LessThanByteString
+                | LessThanEqualsByteString
+                | Sha2_256
+                | Sha3_256
+                | Blake2b_256
+                | VerifyEd25519Signature
+                | AppendString
+                | EqualsString
+                | EncodeUtf8
+                | DecodeUtf8
+                | IfThenElse
+                | ChooseUnit
+                | Trace
+                | FstPair
+                | SndPair
+                | ChooseList
+                | MkCons
+                | HeadList
+                | TailList
+                | NullList
+                | ChooseData
+                | ConstrData
+                | MapData
+                | ListData
+                | IData
+                | BData
+                | UnConstrData
+                | UnMapData
+                | UnListData
+                | UnIData
+                | UnBData
+                | EqualsData
+                | MkPairData
+                | MkNilData
+                | MkNilPairData
+        );
+
+        // batch2: SerialiseData (Vasil, PV 7)
+        let batch2 = matches!(self, SerialiseData);
+
+        // batch3: secp256k1 (Valentine, PV 8)
+        let batch3 = matches!(
+            self,
+            VerifyEcdsaSecp256k1Signature | VerifySchnorrSecp256k1Signature
+        );
+
+        // batch4a: BLS + Keccak + Blake2b_224 (Chang, PV 9 for V3; van Rossem, PV 11 for V1/V2)
+        let batch4a = matches!(
+            self,
+            Bls12_381_G1_Add
+                | Bls12_381_G1_Neg
+                | Bls12_381_G1_ScalarMul
+                | Bls12_381_G1_Equal
+                | Bls12_381_G1_Compress
+                | Bls12_381_G1_Uncompress
+                | Bls12_381_G1_HashToGroup
+                | Bls12_381_G2_Add
+                | Bls12_381_G2_Neg
+                | Bls12_381_G2_ScalarMul
+                | Bls12_381_G2_Equal
+                | Bls12_381_G2_Compress
+                | Bls12_381_G2_Uncompress
+                | Bls12_381_G2_HashToGroup
+                | Bls12_381_MillerLoop
+                | Bls12_381_MulMlResult
+                | Bls12_381_FinalVerify
+                | Keccak_256
+                | Blake2b_224
+        );
+
+        // batch4b: integer-bytestring conversions (Chang, PV 9 for V3; Plomin, PV 10 for V2)
+        let batch4b = matches!(self, IntegerToByteString | ByteStringToInteger);
+
+        // batch5: bitwise operations + Ripemd_160 (Plomin, PV 10 for V3)
+        let batch5 = matches!(
+            self,
+            AndByteString
+                | OrByteString
+                | XorByteString
+                | ComplementByteString
+                | ReadBit
+                | WriteBits
+                | ReplicateByte
+                | ShiftByteString
+                | RotateByteString
+                | CountSetBits
+                | FindFirstSetBit
+                | Ripemd_160
+        );
+
+        // batch6: van Rossem (PV 11) — ExpModInteger, DropList, LengthOfArray, ListToArray, IndexArray
+        // Not explicitly matched because PV >= 11 returns true for all builtins.
+
+        match plutus_version {
+            PlutusVersion::V1 => {
+                if pv >= 11 {
+                    true
+                } else {
+                    batch1
+                }
+            }
+            PlutusVersion::V2 => {
+                if pv >= 11 {
+                    true
+                } else if pv >= 10 {
+                    batch1 || batch2 || batch3 || batch4b
+                } else if pv >= 8 {
+                    batch1 || batch2 || batch3
+                } else {
+                    // PV 7
+                    batch1 || batch2
+                }
+            }
+            PlutusVersion::V3 => {
+                if pv >= 11 {
+                    true
+                } else if pv >= 10 {
+                    batch1 || batch2 || batch3 || batch4a || batch4b || batch5
+                } else {
+                    // PV 9
+                    batch1 || batch2 || batch3 || batch4a || batch4b
+                }
+            }
         }
     }
 }

--- a/crates/uplc/src/flat/decode/error.rs
+++ b/crates/uplc/src/flat/decode/error.rs
@@ -34,4 +34,6 @@ pub enum FlatDecodeError {
     BlsTypeNotSupported,
     #[error("Trailing bytes after script: {0} bytes remaining")]
     TrailingBytes(usize),
+    #[error("Builtin function {1} (tag {0}) is not available in the given language version")]
+    BuiltinNotAvailable(u8, String),
 }

--- a/crates/uplc/src/flat/decode/error.rs
+++ b/crates/uplc/src/flat/decode/error.rs
@@ -32,4 +32,6 @@ pub enum FlatDecodeError {
     MissingTypeTag,
     #[error("BLS type not supported")]
     BlsTypeNotSupported,
+    #[error("Trailing bytes after script: {0} bytes remaining")]
+    TrailingBytes(usize),
 }

--- a/crates/uplc/src/flat/decode/mod.rs
+++ b/crates/uplc/src/flat/decode/mod.rs
@@ -29,12 +29,12 @@ pub fn decode<'a, V>(
     arena: &'a Arena,
     bytes: &[u8],
     plutus_version: PlutusVersion,
-    pv: u32,
+    protocol_version_major: u32,
 ) -> Result<&'a Program<'a, V>, FlatDecodeError>
 where
     V: Binder<'a>,
 {
-    let (program, _remainder) = decode_inner(arena, bytes, plutus_version, pv)?;
+    let (program, _remainder) = decode_inner(arena, bytes, plutus_version, protocol_version_major)?;
     Ok(program)
 }
 
@@ -44,12 +44,12 @@ pub fn decode_strict<'a, V>(
     arena: &'a Arena,
     bytes: &[u8],
     plutus_version: PlutusVersion,
-    pv: u32,
+    protocol_version: u32,
 ) -> Result<&'a Program<'a, V>, FlatDecodeError>
 where
     V: Binder<'a>,
 {
-    let (program, remainder) = decode_inner(arena, bytes, plutus_version, pv)?;
+    let (program, remainder) = decode_inner(arena, bytes, plutus_version, protocol_version)?;
     if remainder > 0 {
         return Err(FlatDecodeError::TrailingBytes(remainder));
     }
@@ -60,7 +60,7 @@ fn decode_inner<'a, V>(
     arena: &'a Arena,
     bytes: &[u8],
     plutus_version: PlutusVersion,
-    pv: u32,
+    protocol_version_major: u32,
 ) -> Result<(&'a Program<'a, V>, usize), FlatDecodeError>
 where
     V: Binder<'a>,
@@ -75,7 +75,11 @@ where
 
     let mut ctx = Ctx { arena };
 
-    let term = decode_term(&mut ctx, &mut decoder, (plutus_version, pv))?;
+    let term = decode_term(
+        &mut ctx,
+        &mut decoder,
+        (plutus_version, protocol_version_major),
+    )?;
 
     decoder.filler()?;
 
@@ -140,8 +144,8 @@ where
 
             let function = builtin::try_from_tag(ctx.arena, builtin_tag)?;
 
-            let (plutus_version, pv) = version_check;
-            if !function.is_available_in(plutus_version, pv) {
+            let (plutus_version, protocol_version_major) = version_check;
+            if !function.is_available_in(plutus_version, protocol_version_major) {
                 return Err(FlatDecodeError::BuiltinNotAvailable(
                     builtin_tag,
                     format!("{:?}", function),

--- a/crates/uplc/src/flat/decode/mod.rs
+++ b/crates/uplc/src/flat/decode/mod.rs
@@ -9,6 +9,7 @@ use bumpalo::collections::Vec as BumpVec;
 
 use crate::arena::Arena;
 use crate::binder::Binder;
+use crate::machine::PlutusVersion;
 use crate::typ::Type;
 use crate::{
     constant::Constant,
@@ -22,31 +23,44 @@ use super::{
     tag::{BUILTIN_TAG_WIDTH, CONST_TAG_WIDTH, TERM_TAG_WIDTH},
 };
 
-pub fn decode<'a, V>(arena: &'a Arena, bytes: &[u8]) -> Result<&'a Program<'a, V>, FlatDecodeError>
-where
-    V: Binder<'a>,
-{
-    let (program, _remainder) = decode_with_remainder(arena, bytes)?;
-    Ok(program)
-}
-
-pub fn decode_strict<'a, V>(
+/// Decode a flat-encoded UPLC program, validating builtins against the given
+/// Plutus language version and protocol version. Allows trailing bytes.
+pub fn decode<'a, V>(
     arena: &'a Arena,
     bytes: &[u8],
+    plutus_version: PlutusVersion,
+    pv: u32,
 ) -> Result<&'a Program<'a, V>, FlatDecodeError>
 where
     V: Binder<'a>,
 {
-    let (program, remainder) = decode_with_remainder(arena, bytes)?;
+    let (program, _remainder) = decode_inner(arena, bytes, plutus_version, pv)?;
+    Ok(program)
+}
+
+/// Decode a flat-encoded UPLC program, validating builtins and rejecting
+/// trailing bytes after the filler.
+pub fn decode_strict<'a, V>(
+    arena: &'a Arena,
+    bytes: &[u8],
+    plutus_version: PlutusVersion,
+    pv: u32,
+) -> Result<&'a Program<'a, V>, FlatDecodeError>
+where
+    V: Binder<'a>,
+{
+    let (program, remainder) = decode_inner(arena, bytes, plutus_version, pv)?;
     if remainder > 0 {
         return Err(FlatDecodeError::TrailingBytes(remainder));
     }
     Ok(program)
 }
 
-fn decode_with_remainder<'a, V>(
+fn decode_inner<'a, V>(
     arena: &'a Arena,
     bytes: &[u8],
+    plutus_version: PlutusVersion,
+    pv: u32,
 ) -> Result<(&'a Program<'a, V>, usize), FlatDecodeError>
 where
     V: Binder<'a>,
@@ -61,7 +75,7 @@ where
 
     let mut ctx = Ctx { arena };
 
-    let term = decode_term(&mut ctx, &mut decoder)?;
+    let term = decode_term(&mut ctx, &mut decoder, (plutus_version, pv))?;
 
     decoder.filler()?;
 
@@ -73,6 +87,7 @@ where
 fn decode_term<'a, V>(
     ctx: &mut Ctx<'a>,
     decoder: &mut Decoder<'_>,
+    version_check: (PlutusVersion, u32),
 ) -> Result<&'a Term<'a, V>, FlatDecodeError>
 where
     V: Binder<'a>,
@@ -84,7 +99,7 @@ where
         tag::VAR => Ok(Term::var(ctx.arena, V::var_decode(ctx.arena, decoder)?)),
         // Delay
         tag::DELAY => {
-            let term = decode_term(ctx, decoder)?;
+            let term = decode_term(ctx, decoder, version_check)?;
 
             Ok(term.delay(ctx.arena))
         }
@@ -92,14 +107,14 @@ where
         tag::LAMBDA => {
             let param = V::parameter_decode(ctx.arena, decoder)?;
 
-            let term = decode_term(ctx, decoder)?;
+            let term = decode_term(ctx, decoder, version_check)?;
 
             Ok(term.lambda(ctx.arena, param))
         }
         // Apply
         tag::APPLY => {
-            let function = decode_term(ctx, decoder)?;
-            let argument = decode_term(ctx, decoder)?;
+            let function = decode_term(ctx, decoder, version_check)?;
+            let argument = decode_term(ctx, decoder, version_check)?;
 
             let term = function.apply(ctx.arena, argument);
 
@@ -113,7 +128,7 @@ where
         }
         // Force
         tag::FORCE => {
-            let term = decode_term(ctx, decoder)?;
+            let term = decode_term(ctx, decoder, version_check)?;
 
             Ok(term.force(ctx.arena))
         }
@@ -125,6 +140,14 @@ where
 
             let function = builtin::try_from_tag(ctx.arena, builtin_tag)?;
 
+            let (plutus_version, pv) = version_check;
+            if !function.is_available_in(plutus_version, pv) {
+                return Err(FlatDecodeError::BuiltinNotAvailable(
+                    builtin_tag,
+                    format!("{:?}", function),
+                ));
+            }
+
             let term = Term::builtin(ctx.arena, function);
 
             Ok(term)
@@ -132,7 +155,7 @@ where
         // Constr
         tag::CONSTR => {
             let tag = decoder.word()?;
-            let fields = decoder.list_with(ctx, decode_term)?;
+            let fields = decoder.list_with(ctx, |ctx, d| decode_term(ctx, d, version_check))?;
             let fields = ctx.arena.alloc(fields);
 
             let term = Term::constr(ctx.arena, tag, fields);
@@ -141,8 +164,8 @@ where
         }
         // Case
         tag::CASE => {
-            let constr = decode_term(ctx, decoder)?;
-            let branches = decoder.list_with(ctx, decode_term)?;
+            let constr = decode_term(ctx, decoder, version_check)?;
+            let branches = decoder.list_with(ctx, |ctx, d| decode_term(ctx, d, version_check))?;
             let branches = ctx.arena.alloc(branches);
 
             Ok(Term::case(ctx.arena, constr, branches))
@@ -345,7 +368,7 @@ mod tests {
         //   ])
         let bytes = hex::decode("0101003370090011aab9d375498109d8668218809f0001ff0001").unwrap();
         let arena = Arena::new();
-        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes);
+        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes, PlutusVersion::V3, 9);
         match program {
             Ok(program) => {
                 let eval_result = program.eval(&arena);
@@ -384,7 +407,7 @@ mod tests {
         )
         .unwrap();
         let arena = Arena::new();
-        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes);
+        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes, PlutusVersion::V3, 9);
         match program {
             Ok(program) => {
                 let eval_result = program.eval(&arena);
@@ -422,7 +445,7 @@ mod tests {
         //   ])
         let bytes = hex::decode("0101003370490021bad357426ae88dd62601049f070eff0001").unwrap();
         let arena = Arena::new();
-        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes);
+        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes, PlutusVersion::V3, 9);
         match program {
             Ok(program) => {
                 let eval_result = program.eval(&arena);

--- a/crates/uplc/src/flat/decode/mod.rs
+++ b/crates/uplc/src/flat/decode/mod.rs
@@ -26,6 +26,31 @@ pub fn decode<'a, V>(arena: &'a Arena, bytes: &[u8]) -> Result<&'a Program<'a, V
 where
     V: Binder<'a>,
 {
+    let (program, _remainder) = decode_with_remainder(arena, bytes)?;
+    Ok(program)
+}
+
+pub fn decode_strict<'a, V>(
+    arena: &'a Arena,
+    bytes: &[u8],
+) -> Result<&'a Program<'a, V>, FlatDecodeError>
+where
+    V: Binder<'a>,
+{
+    let (program, remainder) = decode_with_remainder(arena, bytes)?;
+    if remainder > 0 {
+        return Err(FlatDecodeError::TrailingBytes(remainder));
+    }
+    Ok(program)
+}
+
+fn decode_with_remainder<'a, V>(
+    arena: &'a Arena,
+    bytes: &[u8],
+) -> Result<(&'a Program<'a, V>, usize), FlatDecodeError>
+where
+    V: Binder<'a>,
+{
     let mut decoder = Decoder::new(bytes);
 
     let major = decoder.word()?;
@@ -40,7 +65,9 @@ where
 
     decoder.filler()?;
 
-    Ok(Program::new(arena, version, term))
+    let remainder = decoder.buffer.len() - decoder.pos;
+
+    Ok((Program::new(arena, version, term), remainder))
 }
 
 fn decode_term<'a, V>(

--- a/crates/uplc/src/flat/encode/mod.rs
+++ b/crates/uplc/src/flat/encode/mod.rs
@@ -263,6 +263,7 @@ mod tests {
     use crate::arena::Arena;
     use crate::binder::DeBruijn;
     use crate::flat::decode;
+    use crate::machine::PlutusVersion;
 
     #[test]
     fn roundtrip_program_big_constr_tag() {
@@ -281,7 +282,7 @@ mod tests {
         let bytes_hex = "0101003370090011aab9d37549810cd8668218809f4100420101ff0001";
         let bytes = hex::decode(bytes_hex).unwrap();
         let arena = Arena::new();
-        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes);
+        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes, PlutusVersion::V3, 9);
         match program {
             Ok(program) => {
                 let encoded = encode(program);
@@ -322,7 +323,7 @@ mod tests {
             "0101003370090011bad357426aae78dd526112d8799fc24c033b2e3c9fd0803ce7ffffffff0001";
         let bytes = hex::decode(bytes_hex).unwrap();
         let arena = Arena::new();
-        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes);
+        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes, PlutusVersion::V3, 9);
         match program {
             Ok(program) => {
                 let encoded = encode(program);
@@ -362,7 +363,7 @@ mod tests {
         let bytes_hex = "0101003370490021bad357426ae88dd62601049f070eff0001";
         let bytes = hex::decode(bytes_hex).unwrap();
         let arena = Arena::new();
-        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes);
+        let program: Result<&Program<DeBruijn>, _> = decode(&arena, &bytes, PlutusVersion::V3, 9);
         match program {
             Ok(program) => {
                 let encoded = encode(program);


### PR DESCRIPTION
The deserialization logic in the Haskell node does two things that we currently don't do:
1) rejects scripts with trailing bytes after the filler when the script is PlutusV3
2) rejects scripts that contain builtins that are not available in the `(langauge_version, major protocol version)` tuple

This PR provides a new `deserialize_strict` function that allows the caller (`amaru-ledger`, primarily) to choose whether or not to reject trailing bytes. Both functions reject scripts that contain unsupported builtins