### PR TITLE
Implement case on constant

### DIFF
--- a/crates/uplc/src/flat/decode/decoder.rs
+++ b/crates/uplc/src/flat/decode/decoder.rs
@@ -21,14 +21,6 @@ pub struct Ctx<'a> {
 }
 
 impl<'a> Ctx<'a> {
-    /// Returns true if gating is active and the program version is pre-1.1.0.
-    pub fn program_is_pre_1_1_0(&self) -> bool {
-        match self.version {
-            Some(v) => v.is_less_than_1_1_0(),
-            None => false,
-        }
-    }
-
     /// Returns true if the given builtin is NOT available under the current
     /// plutus_version / protocol_version combination.
     pub fn is_builtin_gated(&self, func: &DefaultFunction) -> bool {

--- a/crates/uplc/src/flat/decode/mod.rs
+++ b/crates/uplc/src/flat/decode/mod.rs
@@ -1,29 +1,25 @@
 mod decoder;
 mod error;
 
-pub use decoder::Ctx;
-pub use decoder::Decoder;
+pub use decoder::{Ctx, Decoder};
 pub use error::FlatDecodeError;
 
 use bumpalo::collections::Vec as BumpVec;
 use num::Zero;
 
-use crate::arena::Arena;
-use crate::binder::Binder;
-use crate::ledger_value::{
-    check_quantity_range, count_stats, CurrencyEntry, LedgerValue, TokenEntry,
-};
-use crate::machine::PlutusVersion;
-use crate::typ::Type;
 use crate::{
+    arena::Arena,
+    binder::Binder,
     constant::Constant,
+    ledger_value::{check_quantity_range, count_stats, CurrencyEntry, LedgerValue, TokenEntry},
+    machine::PlutusVersion,
     program::{Program, Version},
     term::Term,
+    typ::Type,
 };
 
-use super::tag;
 use super::{
-    builtin,
+    builtin, tag,
     tag::{BUILTIN_TAG_WIDTH, CONST_TAG_WIDTH, TERM_TAG_WIDTH},
 };
 
@@ -165,7 +161,7 @@ where
         }
         // Constr
         tag::CONSTR => {
-            if ctx.program_is_pre_1_1_0() {
+            if ctx.version.is_some_and(|v| v.is_less_than_1_1_0()) {
                 return Err(FlatDecodeError::TermNotAvailable(tag::CONSTR, "constr"));
             }
 
@@ -179,7 +175,7 @@ where
         }
         // Case
         tag::CASE => {
-            if ctx.program_is_pre_1_1_0() {
+            if ctx.version.is_some_and(|v| v.is_less_than_1_1_0()) {
                 return Err(FlatDecodeError::TermNotAvailable(tag::CASE, "case"));
             }
 

--- a/crates/uplc/src/machine/cek.rs
+++ b/crates/uplc/src/machine/cek.rs
@@ -384,6 +384,7 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
     }
 
     /// Decompose a constant into (tag, max_branches, fields) for constant-case.
+    #[allow(clippy::type_complexity)]
     fn constant_as_tag_fields<V>(
         &self,
         constant: &'a Constant<'a>,

--- a/crates/uplc/src/machine/cek.rs
+++ b/crates/uplc/src/machine/cek.rs
@@ -1,3 +1,4 @@
+use crate::program::Version;
 use bumpalo::collections::Vec as BumpVec;
 
 use crate::{
@@ -28,7 +29,7 @@ pub struct Machine<'a, B: BuiltinCostModel> {
     slippage: u8,
     pub(super) logs: Vec<String>,
     pub(super) semantics: BuiltinSemantics,
-    pre_v11: bool,
+    version: Version<'a>,
 }
 
 impl<'a, B: BuiltinCostModel> Machine<'a, B> {
@@ -37,7 +38,7 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
         initial_budget: ExBudget,
         costs: CostModel<B>,
         semantics: BuiltinSemantics,
-        pre_v11: bool,
+        version: Version<'a>,
     ) -> Self {
         Machine {
             arena,
@@ -47,7 +48,7 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
             slippage: 200,
             logs: Vec::new(),
             semantics,
-            pre_v11,
+            version,
         }
     }
 
@@ -251,7 +252,7 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
                         Err(MachineError::MissingCaseBranch(branches, value))
                     }
                 }
-                Value::Con(constant) if self.pre_v11 => {
+                Value::Con(constant) if self.version.is_at_least_1_1_0() => {
                     let (tag, max_branches, fields) = self.constant_as_tag_fields(constant)?;
 
                     if branches.len() > max_branches {

--- a/crates/uplc/src/machine/cek.rs
+++ b/crates/uplc/src/machine/cek.rs
@@ -28,6 +28,7 @@ pub struct Machine<'a, B: BuiltinCostModel> {
     slippage: u8,
     pub(super) logs: Vec<String>,
     pub(super) semantics: BuiltinSemantics,
+    pre_v11: bool,
 }
 
 impl<'a, B: BuiltinCostModel> Machine<'a, B> {
@@ -36,6 +37,7 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
         initial_budget: ExBudget,
         costs: CostModel<B>,
         semantics: BuiltinSemantics,
+        pre_v11: bool,
     ) -> Self {
         Machine {
             arena,
@@ -45,6 +47,7 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
             slippage: 200,
             logs: Vec::new(),
             semantics,
+            pre_v11,
         }
     }
 
@@ -248,7 +251,7 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
                         Err(MachineError::MissingCaseBranch(branches, value))
                     }
                 }
-                Value::Con(constant) => {
+                Value::Con(constant) if self.pre_v11 => {
                     let (tag, max_branches, fields) = self.constant_as_tag_fields(constant)?;
 
                     if branches.len() > max_branches {

--- a/crates/uplc/src/machine/cek.rs
+++ b/crates/uplc/src/machine/cek.rs
@@ -3,6 +3,7 @@ use bumpalo::collections::Vec as BumpVec;
 use crate::{
     arena::Arena,
     binder::Eval,
+    constant::Constant,
     machine::{
         context::Context, cost_model::builtin_costs::BuiltinCostModel, env::Env,
         state::MachineState,
@@ -237,13 +238,24 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
             }
             Context::FrameCases(env, branches, context) => match value {
                 Value::Constr(tag, fields) => {
-                    // kind of awkward tbh cause tag is already usize so how can it be bigger
-                    // than the max
-                    // if *tag > usize::MAX {
-                    //     return Err(MachineError::MaxConstrTagExceeded(value));
-                    // }
-
                     if let Some(branch) = branches.get(*tag) {
+                        let frame = self.transfer_arg_stack(fields, context);
+
+                        let state = MachineState::compute(self.arena, frame, env, branch);
+
+                        Ok(state)
+                    } else {
+                        Err(MachineError::MissingCaseBranch(branches, value))
+                    }
+                }
+                Value::Con(constant) => {
+                    let (tag, max_branches, fields) = self.constant_as_tag_fields(constant)?;
+
+                    if branches.len() > max_branches {
+                        return Err(MachineError::MissingCaseBranch(branches, value));
+                    }
+
+                    if let Some(branch) = branches.get(tag) {
                         let frame = self.transfer_arg_stack(fields, context);
 
                         let state = MachineState::compute(self.arena, frame, env, branch);
@@ -365,6 +377,54 @@ impl<'a, B: BuiltinCostModel> Machine<'a, B> {
         }
 
         c
+    }
+
+    /// Decompose a constant into (tag, max_branches, fields) for constant-case.
+    fn constant_as_tag_fields<V>(
+        &self,
+        constant: &'a Constant<'a>,
+    ) -> Result<(usize, usize, &'a [&'a Value<'a, V>]), MachineError<'a, V>>
+    where
+        V: Eval<'a>,
+    {
+        let empty: &'a [&'a Value<'a, V>] = self.arena.alloc(BumpVec::new_in(self.arena.as_bump()));
+        match constant {
+            Constant::Unit => Ok((0, 1, empty)),
+            Constant::Boolean(false) => Ok((0, 2, empty)),
+            Constant::Boolean(true) => Ok((1, 2, empty)),
+            Constant::Integer(i) => {
+                let tag = usize::try_from(*i).map_err(|_| MachineError::outside_usize_bounds(i))?;
+                Ok((tag, usize::MAX, empty))
+            }
+            Constant::ProtoList(ty, items) => {
+                if items.is_empty() {
+                    Ok((1, 2, empty))
+                } else {
+                    let head = Value::con(self.arena, items[0]);
+                    let tail = Value::con(
+                        self.arena,
+                        Constant::proto_list(self.arena, ty, &items[1..]),
+                    );
+
+                    let mut fields = BumpVec::with_capacity_in(2, self.arena.as_bump());
+                    fields.push(head);
+                    fields.push(tail);
+                    Ok((0, 2, self.arena.alloc(fields)))
+                }
+            }
+            Constant::ProtoPair(_, _, first, second) => {
+                let first_val = Value::con(self.arena, first);
+                let second_val = Value::con(self.arena, second);
+
+                let mut fields = BumpVec::with_capacity_in(2, self.arena.as_bump());
+                fields.push(first_val);
+                fields.push(second_val);
+                Ok((0, 1, self.arena.alloc(fields)))
+            }
+            _ => Err(MachineError::NonConstrScrutinized(Value::con(
+                self.arena, constant,
+            ))),
+        }
     }
 
     fn step_and_maybe_spend<V>(&mut self, step: StepKind) -> Result<(), MachineError<'a, V>>

--- a/crates/uplc/src/program.rs
+++ b/crates/uplc/src/program.rs
@@ -83,13 +83,12 @@ where
         plutus_version: PlutusVersion,
         initial_budget: ExBudget,
     ) -> EvalResult<'a, V> {
-        let pre_v11 = !self.version.is_less_than_1_1_0();
         let mut machine = Machine::new(
             arena,
             initial_budget,
             cost_model,
             BuiltinSemantics::from(&plutus_version),
-            pre_v11,
+            *self.version,
         );
         let term = machine.run(self.term);
         let mut info = machine.info();
@@ -150,11 +149,11 @@ impl<'a> Version<'a> {
     }
 
     pub fn is_v1_0_0(&'a self) -> bool {
-        self.0 .0 == 1 && self.0 .1 == 0 && self.0 .2 == 0
+        self.0 == &(1, 0, 0)
     }
 
     pub fn is_v1_1_0(&'a self) -> bool {
-        self.0 .0 == 1 && self.0 .1 == 1 && self.0 .2 == 0
+        self.0 == &(1, 1, 0)
     }
 
     pub fn is_valid_version(&'a self) -> bool {
@@ -162,7 +161,11 @@ impl<'a> Version<'a> {
     }
 
     pub fn is_less_than_1_1_0(&'a self) -> bool {
-        self.0 .0 == 0 || self.0 .1 == 0
+        self.0 < &(1, 1, 0)
+    }
+
+    pub fn is_at_least_1_1_0(&'a self) -> bool {
+        self.0 >= &(1, 1, 0)
     }
 
     pub fn major(&'a self) -> usize {

--- a/crates/uplc/src/program.rs
+++ b/crates/uplc/src/program.rs
@@ -83,11 +83,13 @@ where
         plutus_version: PlutusVersion,
         initial_budget: ExBudget,
     ) -> EvalResult<'a, V> {
+        let pre_v11 = !self.version.is_less_than_1_1_0();
         let mut machine = Machine::new(
             arena,
             initial_budget,
             cost_model,
             BuiltinSemantics::from(&plutus_version),
+            pre_v11,
         );
         let term = machine.run(self.term);
         let mut info = machine.info();


### PR DESCRIPTION
This PR implements case on constant.

There's version gating to check if the version is before 1.1.0, to branch the logic before the protocal version 11 fork and after.