### PR TITLE
Conformance CI Changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - name: Unit tests
+        run: cargo test --lib
+      - name: Textual conformance
+        if: '!cancelled()'
+        run: cargo test --test conformance
+      - name: Flat conformance
+        if: '!cancelled()'
+        run: cargo test --test conformance_flat
 
   audit:
     name: Audit


### PR DESCRIPTION
Make sure that both the text and flat conformance test both always run, even if suite one fails